### PR TITLE
Update SDL3 backend SDL_EVENT_DISPLAY

### DIFF
--- a/backends/imgui_impl_sdl3.cpp
+++ b/backends/imgui_impl_sdl3.cpp
@@ -322,8 +322,8 @@ bool ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event)
             return true;
         }
         case SDL_EVENT_DISPLAY_ORIENTATION:
-        case SDL_EVENT_DISPLAY_CONNECTED:
-        case SDL_EVENT_DISPLAY_DISCONNECTED:
+        case SDL_EVENT_DISPLAY_ADDED:
+        case SDL_EVENT_DISPLAY_REMOVED:
         case SDL_EVENT_DISPLAY_MOVED:
         case SDL_EVENT_DISPLAY_CONTENT_SCALE_CHANGED:
         {


### PR DESCRIPTION
SDL3 display events have been renamed by the following commit https://github.com/libsdl-org/SDL/commit/c98a14fdeba77e7e6fccacc36a6657839a801f40